### PR TITLE
docs: update paths in readne

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 <div align="center">
     <h1>Finity UI</h1>
-    <strong> Web3 component library for Tailwind CSS based on Finity Design System💜</strong>
+    <strong>Open-source Web3 component library for Tailwind CSS based on Finity Design System 💜</strong>
 </div>
 <br>
 <div align="center">
 <a href="https://www.npmjs.com/package/finity-ui">
         <img alt="npm" src="https://img.shields.io/npm/v/finity-ui">
     </a>
-    <a href="https://github.com/manazpr/finity-ui/actions">
-        <img src="https://img.shields.io/github/workflow/status/manazpr/finity-ui/CI"  alt="build status">
+    <a href="https://github.com/finity-ui/finity-ui/actions">
+        <img src="https://img.shields.io/github/workflow/status/finity-ui/finity-ui/CI"  alt="build status">
     </a>
-    <a href="https://deepsource.io/gh/manazpr/finity-ui">
-        <img src="https://deepsource.io/gh/manazpr/finity-ui.svg/?label=active+issues&show_trend=true" alt="GitHub actions">
+    <a href="https://deepsource.io/gh/finity-ui/finity-ui">
+        <img src="https://deepsource.io/gh/finity-ui/finity-ui.svg/?label=active+issues&show_trend=true" alt="GitHub actions">
     </a>
-    <a href="https://gitpod.io/#https://github.com/manazpr/finity-ui">
+    <a href="https://gitpod.io/#https://github.com/finity-ui/finity-ui">
         <img src="https://img.shields.io/badge/setup-automated-blue?logo=gitpod" alt="Gitpod">
     </a>
     <a href="https://twitter.com/manazpr">
@@ -22,14 +22,14 @@
 </div>
 <div align="center">
     <br>
-    <a href="https://finity-ui.netlify.app/"><b>finity-ui.netlify.app »</b></a>
+    <a href="https://finityui.com/"><b>finityui.com »</b></a>
     <br><br>
-    <a href="https://github.com/manazpr/finity-ui/issues/new"><b>Issues</b></a>
+    <a href="https://github.com/finity-ui/finity-ui/issues/new"><b>Issues</b></a>
 </div>
 
 ## Documentation
 
-Documentation for `finity-ui` is not yet finished.
+WIP
 
 ## Getting started
 
@@ -51,6 +51,9 @@ OR
 yarn add finity-ui
 ```
 
+## 💕 Contributors
+
+We love contributors! Feel free to contribute to this project but please read the [Contributing Guidelines](CONTRIBUTING.md) before opening an issue or PR so you understand the branching strategy and local development environment.
 ## Figma
 
 This library is based on Finity design system for Web3 by Polygon.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
         <img alt="npm" src="https://img.shields.io/npm/v/finity-ui">
     </a>
     <a href="https://github.com/finity-ui/finity-ui/actions">
-        <img src="https://img.shields.io/github/workflow/status/finity-ui/finity-ui/CI"  alt="build status">
+        <img src="https://img.shields.io/github/actions/workflow/status/finity-ui/finity-ui/main.yml"  alt="build status">
     </a>
     <a href="https://deepsource.io/gh/finity-ui/finity-ui">
         <img src="https://deepsource.io/gh/finity-ui/finity-ui.svg/?label=active+issues&show_trend=true" alt="GitHub actions">
@@ -54,6 +54,7 @@ yarn add finity-ui
 ## 💕 Contributors
 
 We love contributors! Feel free to contribute to this project but please read the [Contributing Guidelines](CONTRIBUTING.md) before opening an issue or PR so you understand the branching strategy and local development environment.
+
 ## Figma
 
 This library is based on Finity design system for Web3 by Polygon.


### PR DESCRIPTION
Fixes an issue in the documentation where the path of image shields was incorrect and the website link was broken. Here are the specific changes that were made:

Updated the paths of image shields in the documentation to the correct location.
Fixed the broken website link by updating it to the correct URL.
This should improve the user experience by making the documentation easier to read and navigate. 